### PR TITLE
task/BAN-112 Update get asset endpoint with contains pii field

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,40 @@
-# Version
+## 📝 Description
 
-- 
+> Please include a summary of the change and the related issue(s).
+> What is the motivation behind this PR?
 
-# Ticket URL
+---
 
-- 
+## ✅ Type of Change
 
-# Changes Made
+> Check all that apply:
 
-- 
+- [ ] Bug fix 🐞
+- [ ] New feature ✨
+- [ ] Refactor ♻️
+- [ ] Documentation update 📚
+- [ ] Test update 🧪
+- [ ] CI/CD update ⚙️
+- [ ] Other (please describe):
 
-# Checklist
+---
 
-Please verify this checklist so that you are sure this is ready for review.
+## 🔍 Changes Made
 
-- [ ] Updated `package.json` & `schema.json` versions - they need to be the same
-- [ ] Verify there are no issues with the schema.json by running `npm run verify`
-- [ ] All objects have a properites list, `required` array and `additionalProperties` set to `false`
+> Briefly list the key changes:
+
+---
+
+## 🧩 Checklist
+
+> Make sure you’ve done these:
+
+- [ ] I have updated `package.json` & `schema.json` versions - they need to be the same
+- [ ] I have verified there are no issues with the `schema.json` by running `npm run lint`
+- [ ] I have verified that all objects have a properties list, `required` array and `additionalProperties` set to `false`
+
+---
+
+## 🙋‍♂️ Notes for Reviewers
+
+> Anything specific to watch out for, tricky parts, assumptions made, or questions to raise?

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -1232,8 +1232,9 @@
         "properties": {
           "contains_pii": {
             "type": "boolean",
-            "description": "Is the asset contains PII",
-            "example": false
+            "description": "Does the asset contains PII",
+            "example": false,
+            "nullable": true
           },
           "id": {
             "type": "integer",

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -1230,6 +1230,11 @@
       "AssetWithInfoFields": {
         "type": "object",
         "properties": {
+          "contains_pii": {
+            "type": "boolean",
+            "description": "Is the asset contains PII",
+            "example": false
+          },
           "id": {
             "type": "integer",
             "description": "The asset id",
@@ -1340,6 +1345,7 @@
         },
         "additionalProperties": false,
         "required": [
+          "contains_pii",
           "id",
           "title",
           "filename",

--- a/public/refs/components/schemas/AssetWithInfoFields.json
+++ b/public/refs/components/schemas/AssetWithInfoFields.json
@@ -3,8 +3,9 @@
   "properties": {
     "contains_pii": {
       "type": "boolean",
-      "description": "Is the asset contains PII",
-      "example": false
+      "description": "Does the asset contains PII",
+      "example": false,
+      "nullable": true
     },
     "id": {
       "type": "integer",

--- a/public/refs/components/schemas/AssetWithInfoFields.json
+++ b/public/refs/components/schemas/AssetWithInfoFields.json
@@ -1,6 +1,11 @@
 {
   "type": "object",
   "properties": {
+    "contains_pii": {
+      "type": "boolean",
+      "description": "Is the asset contains PII",
+      "example": false
+    },
     "id": {
       "type": "integer",
       "description": "The asset id",
@@ -111,6 +116,7 @@
   },
   "additionalProperties": false,
   "required": [
+    "contains_pii",
     "id",
     "title",
     "filename",


### PR DESCRIPTION
## 📝 Description

> Please include a summary of the change and the related issue(s).
> What is the motivation behind this PR?

Asset should include contains_pii field now.

---

## ✅ Type of Change

> Check all that apply:

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Refactor ♻️
- [ ] Documentation update 📚
- [ ] Test update 🧪
- [ ] CI/CD update ⚙️
- [ ] Other (please describe):

---

## 🔍 Changes Made

> Briefly list the key changes:

Added new field to Asset schema called contains_pii

---

## 🧩 Checklist

> Make sure you’ve done these:

- [x] I have updated `package.json` & `schema.json` versions - they need to be the same
- [x] I have verified there are no issues with the `schema.json` by running `npm run lint`
- [x] I have verified that all objects have a properties list, `required` array and `additionalProperties` set to `false`

---

## 🙋‍♂️ Notes for Reviewers

> Anything specific to watch out for, tricky parts, assumptions made, or questions to raise?

None
