### PR TITLE
ci: replace ACCESS_PAT_TOKEN with GitHub App token in workflows

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,16 +13,25 @@ jobs:
     name: Create Pre-Release
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 2786925
+          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Retrieve Version
         id: version
         run: echo "value=$(node -pe 'require("./package.json").version')-dev.${{ github.run_number }}" >> $GITHUB_OUTPUT
       - name: Create Release
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.ACCESS_PAT_TOKEN}}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs').promises;
 
@@ -74,18 +83,25 @@ jobs:
     needs: create-pre-release
     if: ${{ !github.event.pull_request.draft }}
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 2786925
+          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Trigger Workflow
         run: |
           set -e
           curl -X POST https://api.github.com/repos/Chillibean/trial-containers-api-client-sdk/dispatches \
           -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u ${{ secrets.ACCESS_PAT_TOKEN }} \
+          -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
           --data '{"event_type": "trigger-pre-release", "client_payload": { "version": "${{ needs.create-pre-release.outputs.version }}" }}' \
           --fail
       - name: Pull Request Comment
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.ACCESS_PAT_TOKEN}}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { repo: { owner, repo } } = context;
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,25 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 2786925
+          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Retrieve Version
         id: version
         run: echo "value=$(node -pe 'require("./package.json").version')" >> $GITHUB_OUTPUT
       - name: Create Release
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.ACCESS_PAT_TOKEN}}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs').promises;
 
@@ -67,11 +76,20 @@ jobs:
     name: Detele Pre-Releases
     runs-on: ubuntu-latest
     needs: create-release
+    permissions:
+      contents: write
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 2786925
+          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Delete Releases
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.ACCESS_PAT_TOKEN}}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs').promises;
 
@@ -104,18 +122,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 2786925
+          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Trigger Workflow
         run: |
           set -e
           curl -X POST https://api.github.com/repos/Chillibean/trial-containers-api-client-sdk/dispatches \
           -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u ${{ secrets.ACCESS_PAT_TOKEN }} \
+          -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
           --data '{"event_type": "trigger-release", "client_payload": { "version": "${{ needs.create-release.outputs.version }}" }}' \
           --fail
       - name: Get Pull Request Number
         id: pr
         env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number')
 
@@ -128,7 +153,7 @@ jobs:
         uses: actions/github-script@v7
         if: ${{ steps.pr.outputs.number != 'none' }}
         with:
-          github-token: ${{secrets.ACCESS_PAT_TOKEN}}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { repo: { owner, repo } } = context;
 
@@ -147,9 +172,18 @@ jobs:
     name: Publish to GitHub Pages
     runs-on: ubuntu-latest
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: 2786925
+          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -161,7 +195,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.ACCESS_PAT_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           publish_dir: ./dist
 
   publish-to-swagger-hub:


### PR DESCRIPTION
Use actions/create-github-app-token@v2 with API_SPEC_APP_PRIVATE_KEY. Switch repository_dispatch curl to Bearer auth. Add job permissions where required for releases and GitHub Pages.

<!-- markdownlint-disable MD033 -->

## 📝 Description/Version

<!-- Brief summary of changes and what problem this solves -->

**Resolves:** #issue-number

---

## ✅ Type of Change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Refactor ♻️
- [ ] Tooling/Scripts 🛠️
- [ ] Test update 🧪
- [ ] Other (please describe):

---

## 🔍 Changes Made

> Briefly list the key changes:

---

## Impact

**Breaking changes:**

- [ ] ✅ No breaking changes
- [ ] ⚠️ Yes - breaking changes (explain below)

> If breaking change, describe the impact

---

## 🧩 Checklist

> Make sure you've done these:

- [ ] Updated `package.json` & `schema.json` versions - they need to be the same
- [ ] Verify there are no issues with the schema.json by running `npm run verify`
- [ ] All objects have a properites list, `required` array and `additionalProperties` set to `false`

---

## Post-Merge Steps

<!-- Any manual steps needed after merge -->

-
-

---

## 🙋‍♂️ Notes for Reviewers

> Anything specific to watch out for, tricky parts, assumptions made, or questions to raise?
