### PR TITLE
fix/3480 bump lodash to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5897,9 +5897,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "react-dom": "^18.2.0",
     "swagger-ui-react": "^5.6.2"
   },
-  "overrides": {
-    "lodash": "4.18.1"
-  },
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "react-dom": "^18.2.0",
     "swagger-ui-react": "^5.6.2"
   },
+  "overrides": {
+    "lodash": "4.18.1"
+  },
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",


### PR DESCRIPTION
## Summary

lodash was flagged (SCA) for known vulnerabilities in this repo. This PR pins the transitive `lodash` dependency to 4.18.1 (the latest published release on npm) via an npm `overrides` entry and regenerates `package-lock.json` so the resolved version and integrity hash match. The repo was previously resolving lodash 4.17.21.

## Changed files

- `package.json` — added an `overrides` entry pinning `lodash` to `4.18.1` (lodash is only a transitive dependency, so there is no direct dependency line to bump)
- `package-lock.json` — regenerated so `node_modules/lodash` resolves to 4.18.1 with the registry integrity hash

## Fix type

Dependency (SCA) / Dependency Version Bump (from triage)

---

Automated fix for [AB#3480](https://dev.azure.com/chillipharm/Issues%20and%20Vulnerabilities/_workitems/edit/3480), generated by the ChilliPharm fix-flow action agent from a triaged work item. Review before merging like any other PR.